### PR TITLE
Use local report list

### DIFF
--- a/Capture report views/index.html
+++ b/Capture report views/index.html
@@ -130,7 +130,7 @@
 
     // Restore report iframe on load
     document.addEventListener("DOMContentLoaded", function () {
-      fetch("https://poddnahh.github.io/UHCapp/reportList.json")
+      fetch("./reportList.json")
         .then(response => response.json())
         .then(reports => {
           if (!reports || reports.length === 0) {

--- a/Capture report views/js/index.js
+++ b/Capture report views/js/index.js
@@ -1,7 +1,7 @@
 document.addEventListener("DOMContentLoaded", function () {
   console.log("DOM loaded");
 
-  fetch("https://poddnahh.github.io/UHCapp/reportList.json")
+  fetch("./reportList.json")
     .then(response => {
       console.log("reportList.json fetched");
       return response.json();

--- a/Capture report views/reportList.json
+++ b/Capture report views/reportList.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "ProjectSummary",
+    "url": "https://app.powerbi.com/view?r=eyJrIjoiMGY3Mzk5NDQtMDI1OS00YmUxLTgyNDAtODQzN2IzYjQyNGYxIiwidCI6ImFiMTk0ZTAxLTZkYzctNGM2YS1iYmIxLTY4YzEyYzc0NGI5NyJ9"
+  },
+  {
+    "name": "ProjectSummary2",
+    "url": "https://app.powerbi.com/view?r=eyJrIjoiNWRjNGY2YjMtNTdkZS00OTI3LWI1YmYtZTAwMWEyMmNkZTAxIiwidCI6ImFiMTk0ZTAxLTZkYzctNGM2YS1iYmIxLTY4YzEyYzc0NGI5NyJ9"
+  },
+  {
+    "name": "ProjectSummary3",
+    "url": "https://app.powerbi.com/view?r=eyJrIjoiMWFkOWI5OWEtZjQxMS00YTBlLWFhYWMtN2Q0ZTY5NWMxMTllIiwidCI6ImFiMTk0ZTAxLTZkYzctNGM2YS1iYmIxLTY4YzEyYzc0NGI5NyJ9"
+  },
+  {
+    "name": "ProjectSummary4",
+    "url": "https://app.powerbi.com/view?r=eyJrIjoiYjkwZmJjMTYtMDAyYS00ZWU1LTliYzQtNTBkMzQ2ZWQ4ODViIiwidCI6ImFiMTk0ZTAxLTZkYzctNGM2YS1iYmIxLTY4YzEyYzc0NGI5NyJ9"
+  }
+]


### PR DESCRIPTION
## Summary
- fetch the local reportList.json in Capture report views
- same update for supporting javascript
- include local reportList.json for offline testing

## Testing
- `npm test` *(fails: missing script)*
- `curl http://localhost:8000/Capture%20report%20views/reportList.json`

------
https://chatgpt.com/codex/tasks/task_e_68533ba333d8832496a28acbce1ceea3