### PR TITLE
Fix incorrect property for report URL

### DIFF
--- a/Customize report colors and mode/js/globals.js
+++ b/Customize report colors and mode/js/globals.js
@@ -16,7 +16,11 @@ async function loadReportIntoSession() {
         const reports = await response.json();
 
         if (reports && reports.length > 0) {
-            reportConfig.embedUrl = reports[0].embedUrl;
+            // reportList.json stores the public report under the "url" key
+            // (not "embedUrl" like the original playground examples). Use
+            // that property to populate the configuration so the sample can
+            // locate the report correctly.
+            reportConfig.embedUrl = reports[0].url;
             console.log("Loaded report URL:", reportConfig.embedUrl);
         } else {
             console.error("reportList.json is empty or missing.");

--- a/Customize report colors and mode/js/index.js
+++ b/Customize report colors and mode/js/index.js
@@ -22,11 +22,14 @@ async function loadFirstReport() {
         const reportList = await response.json();
         const firstReport = reportList[0];
 
-        if (!firstReport || !firstReport.embedUrl) {
+        // The report list uses the property name "url" for the public
+        // report link. Align with that instead of the older "embedUrl" key
+        // used in some samples.
+        if (!firstReport || !firstReport.url) {
             throw new Error("No valid report URL found.");
         }
 
-        embedReport(firstReport.embedUrl);
+        embedReport(firstReport.url);
     } catch (error) {
         console.error("Failed to load reportList.json:", error);
         overlay.hide();


### PR DESCRIPTION
## Summary
- fetch report URL from `url` field rather than `embedUrl`
- update index.js and globals.js accordingly

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685339b355ac8324ab0e07ab2f9b6975