### PR TITLE
Add Node tests for bookmark URL parsing

### DIFF
--- a/Capture report views/js/share_bookmark.js
+++ b/Capture report views/js/share_bookmark.js
@@ -9,13 +9,15 @@ function setReportAccessibilityProps(report) {
     report.setComponentTabIndex(0);
 }
 
-$(document).ready(function () {
+if (typeof window !== "undefined" && window.document && typeof $ !== "undefined") {
+    $(document).ready(function () {
 
-    // Bootstrap the bookmark container
-    powerbi.bootstrap(bookmarkContainer, reportConfig);
+        // Bootstrap the bookmark container
+        powerbi.bootstrap(bookmarkContainer, reportConfig);
 
-    embedSharedBookmarkReport();
-});
+        embedSharedBookmarkReport();
+    });
+}
 
 // Embed shared report with bookmark on load
 async function embedSharedBookmarkReport() {
@@ -100,3 +102,9 @@ function getBookmarkNameFromURL() {
     // Returns the ID of the Bookmark
     return decodeURIComponent(results[2]);
 }
+
+// Export for testing environments
+if (typeof module !== "undefined") {
+    module.exports = { getBookmarkNameFromURL };
+}
+

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
 		"type": "git",
 		"url": "https://powerbi.visualstudio.com/DefaultCollection/Embedded/_git/playground-showcases"
 	},
-	"author": "Microsoft",
-	"files": [
-		"Personalize top insights",
-		"Capture report views",
-		"Customize report colors and mode",
-		"Go from insights to quick action",
-		"Quickly create and personalize visuals"
-	]
+        "author": "Microsoft",
+        "files": [
+                "Personalize top insights",
+                "Capture report views",
+                "Customize report colors and mode",
+                "Go from insights to quick action",
+                "Quickly create and personalize visuals"
+        ],
+        "scripts": {
+                "test": "node --test \"tests/share_bookmark.spec.js\""
+        }
 }

--- a/tests/share_bookmark.spec.js
+++ b/tests/share_bookmark.spec.js
@@ -1,0 +1,26 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { getBookmarkNameFromURL } = require('../Capture report views/js/share_bookmark.js');
+
+function setup(url) {
+  global.regex = new RegExp('[?&]id(=([^&#]*)|&|#|$)');
+  global.window = { location: { href: url }, parent: { location: {} } };
+  window.parent.location = window.location; // make them equal
+  global.document = { location: window.location, referrer: url };
+}
+
+test('returns null when no id is present', () => {
+  setup('https://example.com/report');
+  assert.strictEqual(getBookmarkNameFromURL(), null);
+});
+
+test('parses id from ?id=value', () => {
+  setup('https://example.com/report?id=bookmark1');
+  assert.strictEqual(getBookmarkNameFromURL(), 'bookmark1');
+});
+
+test('parses id from &id=value', () => {
+  setup('https://example.com/report?foo=bar&id=bookmark2');
+  assert.strictEqual(getBookmarkNameFromURL(), 'bookmark2');
+});
+


### PR DESCRIPTION
## Summary
- export `getBookmarkNameFromURL` and guard DOM usage for Node
- add Node test verifying URL bookmark parsing
- add `npm test` script using Node's built-in test runner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68534031e04883249c6c66150bfb194a