### PR TITLE
Add missing styles to report views

### DIFF
--- a/Capture report views/index.html
+++ b/Capture report views/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Capture Report Views</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.css" rel="stylesheet">
+  <link rel="stylesheet" href="css/header.css">
+  <link rel="stylesheet" href="css/report.css">
   <link rel="stylesheet" href="css/modal.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- include header and report stylesheet links in Capture Report Views page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853573ca3b483248da89476ed995d6d